### PR TITLE
fix: consider the space occupied by feedback message in textinput

### DIFF
--- a/src/components/text-input/TextInput.css
+++ b/src/components/text-input/TextInput.css
@@ -8,6 +8,7 @@
 .wrapper {
     min-width: 28rem;
     max-width: 65rem;
+    min-height: 9.1rem;
     display: flex;
     flex-direction: column;
 


### PR DESCRIPTION
NOTE: For some specific use cases in `nomios-web`, like inside the device info step of the create identity modal, there is a CSS transform applied that should probably be removed.