### PR TITLE
fix: fix missing currentColor in SVG css

### DIFF
--- a/src/components/logo/Logo.css
+++ b/src/components/logo/Logo.css
@@ -1,7 +1,6 @@
 .container {
     display: inline-flex;
     font-size: 1rem;
-    fill: currentColor;
 
     &.vertical {
         flex-direction: column;

--- a/src/components/svg/Svg.css
+++ b/src/components/svg/Svg.css
@@ -1,6 +1,7 @@
 .svgWrapper {
     display: inline-block;
     vertical-align: middle;
+    fill: currentColor;
 
     & svg {
         width: inherit;


### PR DESCRIPTION
In the readme we state:

> By default, `fill` inherits from the current `color`.

Which wasn't the case.