### PR TITLE
fix: fix  FlowModal not working in a production build

### DIFF
--- a/src/components/modals/flow-modal/FlowModalContents.js
+++ b/src/components/modals/flow-modal/FlowModalContents.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { castArray, isNumber, isEqual } from 'lodash';
+import { isNumber, isEqual } from 'lodash';
 import Logo from '../../logo';
 import { ModalClose } from '../../modal-base';
 import { LAYOUT, LAYOUT_TRANSITION } from './utils/constants';
@@ -18,7 +18,7 @@ class FlowModalContents extends Component {
             console.error('FlowModal must have at least 1 step');
         }
 
-        const flatChildren = flatContentsChildren(castArray(props.children));
+        const flatChildren = flatContentsChildren(props.children);
 
         const currentChildrenIds = flatChildren.map((child) => ({ id: child.props.id }));
         const oldChildrenIds = state.flatChildren !== null && state.flatChildren.map((child) => ({ id: child.props.id }));

--- a/src/components/modals/flow-modal/utils/flatContentsChildren.js
+++ b/src/components/modals/flow-modal/utils/flatContentsChildren.js
@@ -1,22 +1,15 @@
-import { get } from 'lodash';
+import { Fragment } from 'react';
+import { castArray } from 'lodash';
+import FlowModalStep from '../FlowModalStep';
 
-const flatContentsChildren = (array, depth = 1) => array.reduce((acc, item) => {
+const flatContentsChildren = (children) => castArray(children).reduce((acc, item) => {
     if (item) {
-        if (Array.isArray(item) && depth > 0) {
-            acc.push(...flatContentsChildren(item, depth - 1));
+        if (item.type === Fragment) {
+            acc.push(...flatContentsChildren(item.props.children));
+        } else if (item.type === FlowModalStep) {
+            acc.push(item);
         } else {
-            const type = item.type ? get(item, 'type.name', item.type).toString() : typeof item;
-
-            switch (type) {
-            case 'FlowModalStep':
-                acc.push(item);
-                break;
-            case 'Symbol(react.fragment)':
-                acc.push(...item.props.children);
-                break;
-            default:
-                console.error(`FlowModal only accepts children of type <FlowModalStep>. Found: ${type}`);
-            }
+            console.error('FlowModal only accepts children of type <FlowModalStep>');
         }
     }
 


### PR DESCRIPTION
In production, the `name` is mangled, meaning we must not do comparisons against it.