### PR TITLE
fix: typo in svg component

### DIFF
--- a/src/components/svg/Svg.js
+++ b/src/components/svg/Svg.js
@@ -5,7 +5,7 @@ import Cancelable from 'cancel.it';
 import styles from './Svg.css';
 
 class Icon extends Component {
-    static getDeriveStateFromProps(props, state) {
+    static getDerivedStateFromProps(props, state) {
         return {
             contents: typeof props.svg === 'string' ? props.svg : state.contents,
         };


### PR DESCRIPTION
Currently, the `Svg` component has a typo in the `getDerivedStateFromProps` method.

This means that if the prop `svg` is to be changed, the component will not re-render correctly.
Also, it means that using it as a regular import (instead of a dynamic import) does not work.