### PR TITLE
fix: fix badge component

### DIFF
--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -3,11 +3,12 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import styles from './Badge.css';
 
-const Badge = ({ selected, disabled, hideOverflow, children, onClick, ...rest }) => {
+const Badge = ({ selected, disabled, hideOverflow, children, onClick, className, ...rest }) => {
     const finalClassName = classNames(
         styles.badge,
         selected && styles.selected,
-        hideOverflow && styles['hide-overflow']
+        hideOverflow && styles['hide-overflow'],
+        className
     );
 
     return (
@@ -23,6 +24,7 @@ Badge.propTypes = {
     selected: PropTypes.bool,
     disabled: PropTypes.bool,
     onClick: PropTypes.func,
+    className: PropTypes.string,
     hideOverflow: PropTypes.bool,
     children: PropTypes.node.isRequired,
 };

--- a/src/components/badge/README.md
+++ b/src/components/badge/README.md
@@ -18,6 +18,6 @@ import { Badge } from '@nomios/web-uikit';
 | selected | boolean | false | Sets the badge as selected |
 | disabled | boolean | false | Sets the disable state |
 | onClick | function | | Sets a function to be called when the badge is clicked |
-| hideOverflow | boolean | true | Sets a maximum width on te component, making the overflowing content hidden |
+| hideOverflow | boolean | true | Sets a maximum width on the component, making the overflowing content hidden |
 
 **Note:** Any other properties supplied to this component will be spread to the root element.


### PR DESCRIPTION
This PR adds a `className` prop to `<Badge>` component and fixes a readme typo: `te` -> `the`