### PR TITLE
feat: add modal-global

### DIFF
--- a/src/components/modal-global/ModalGlobalConsumer.js
+++ b/src/components/modal-global/ModalGlobalConsumer.js
@@ -1,0 +1,5 @@
+import ModalGlobalContext from './ModalGlobalContext';
+
+const ModalConsumer = ModalGlobalContext.Consumer;
+
+export default ModalConsumer;

--- a/src/components/modal-global/ModalGlobalContext.js
+++ b/src/components/modal-global/ModalGlobalContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const ModalGlobalContext = createContext();
+
+export default ModalGlobalContext;

--- a/src/components/modal-global/ModalGlobalProvider.js
+++ b/src/components/modal-global/ModalGlobalProvider.js
@@ -1,0 +1,73 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import ModalGlobalContext from './ModalGlobalContext';
+
+class ModalGlobalProvider extends Component {
+    state = {
+        open: false,
+        component: null,
+        props: {},
+        providerValue: {
+            openModal: undefined,
+            closeModal: undefined,
+        },
+    };
+
+    constructor() {
+        super();
+
+        this.state.providerValue.openModal = this.handleOpenModal;
+        this.state.providerValue.closeModal = this.handleCloseModal;
+    }
+
+    render() {
+        return (
+            <ModalGlobalContext.Provider value={ this.state.providerValue }>
+                <Fragment>
+                    { this.renderModal() }
+                    { this.props.children }
+                </Fragment>
+            </ModalGlobalContext.Provider>
+        );
+    }
+
+    renderModal() {
+        const { component: Modal, props, open } = this.state;
+
+        if (!Modal) {
+            return null;
+        }
+
+        return (
+            <Modal { ...props }
+                open={ open }
+                onRequestClose={ this.handleCloseModal }
+                onExited={ this.handleOnExited } />
+        );
+    }
+
+    handleOpenModal = (Modal) => {
+        this.setState({
+            open: true,
+            props: Modal.props,
+            component: Modal.type,
+        });
+    };
+
+    handleCloseModal = () => {
+        this.setState({
+            open: false,
+        });
+    };
+
+    handleOnExited = () => this.setState({
+        props: {},
+        component: null,
+    });
+}
+
+ModalGlobalProvider.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default ModalGlobalProvider;

--- a/src/components/modal-global/README.md
+++ b/src/components/modal-global/README.md
@@ -4,10 +4,20 @@ A global modal react provider. You can open and close modals imperatively (i.e. 
 
 ## Usage
 
-**With `withModalGlobal()` hook:**
+**Setup `<ModalGlobalProvider />`:**
 
 ```jsx
-import { ModalGlobalProvider, withModalGlobal, Modal, ModalClose, Button } from '../src';
+import { ModalGlobalProvider } from '@nomios/web-uikit'
+
+<ModalGlobalProvider>
+    <App />
+</ModalGlobalProvider>
+```
+
+**With `withModalGlobal()` HOC:**
+
+```jsx
+import { withModalGlobal, Modal, ModalClose, Button } from '@nomios/web-uikit';
 import { Transition } from 'react-transition-group';
 
 const FadeModal = ({ children, ...rest }) => (
@@ -31,19 +41,12 @@ const WrappedComponent = withModalGlobal(({ globalModal: { openModal } }) => (
         Open Modal Imperatively
     </Button>
 ));
-
-<ModalGlobalProvider>
-    <OtherComponent />
-    <ParentComponent>
-        <MyComponent />
-    </ParentComponent>
-</ModalGlobalProvider>
 ```
 
 **With `<ModalGlobalConsumer>` component:**
 
 ```jsx
-import { ModalGlobalProvider, ModalGlobalConsumer, Modal, ModalClose, Button } from '../src';
+import { ModalGlobalConsumer, Modal, ModalClose, Button } from '@nomios/web-uikit';
 
 const FadeModal = ({ children, ...rest }) => (
     <Modal { ...rest }>
@@ -72,13 +75,6 @@ const MyComponent = () => {
         </ModalGlobalConsumer>
     )
 };
-
-<ModalGlobalProvider>
-    <OtherComponent />
-    <ParentComponent>
-        <MyComponent />
-    </ParentComponent>
-</ModalGlobalProvider>
 ```
 
 ## API
@@ -105,7 +101,7 @@ The `<ModalGlobalConsumer>` component allows you to trigger a modal imperatively
 
 ### withModalGlobal(component)
 
-The hook version of the <ModalGlobalConsumer> component. The injected props are exactly the same of the <ModalGlobalConsumer> children render prop:
+The HOC version of the <ModalGlobalConsumer> component. The injected props are exactly the same of the <ModalGlobalConsumer> children render prop:
 
 - `closeModal(component)`
 

--- a/src/components/modal-global/README.md
+++ b/src/components/modal-global/README.md
@@ -1,0 +1,112 @@
+# Global modal
+
+A global modal react provider. You can open and close modals imperatively (i.e. separately from the Component `render` function).
+
+## Usage
+
+**With `withModalGlobal()` hook:**
+
+```jsx
+import { ModalGlobalProvider, withModalGlobal, Modal, ModalClose, Button } from '../src';
+import { Transition } from 'react-transition-group';
+
+const FadeModal = ({ children, ...rest }) => (
+    <Modal { ...rest }>
+        <Transition timeout={ 300 }>
+            { (state) => (
+                <div style={ {
+                    ...{ padding: '5rem', transition: 'opacity 300ms ease-in-out' },
+                    ...{ opacity: state === 'entering' || state === 'entered' ? 1 : 0 },
+                } }>
+                    <ModalClose />
+                    I'm a text in a modal.
+                </div>
+            ) }
+        </Transition>
+    </Modal>
+);
+
+const WrappedComponent = withModalGlobal(({ globalModal: { openModal } }) => (
+    <Button onClick={ () => openModal(<FadeModal />) }>
+        Open Modal Imperatively
+    </Button>
+));
+
+<ModalGlobalProvider>
+    <OtherComponent />
+    <ParentComponent>
+        <MyComponent />
+    </ParentComponent>
+</ModalGlobalProvider>
+```
+
+**With `<ModalGlobalConsumer>` component:**
+
+```jsx
+import { ModalGlobalProvider, ModalGlobalConsumer, Modal, ModalClose, Button } from '../src';
+
+const FadeModal = ({ children, ...rest }) => (
+    <Modal { ...rest }>
+        <Transition timeout={ 300 }>
+            { (state) => (
+                <div style={ {
+                    ...{ padding: '5rem', transition: 'opacity 300ms ease-in-out' },
+                    ...{ opacity: state === 'entering' || state === 'entered' ? 1 : 0 },
+                } }>
+                    <ModalClose />
+                    I'm a text in a modal.
+                </div>
+            ) }
+        </Transition>
+    </Modal>
+);
+
+const MyComponent = () => {
+    return (
+        <ModalGlobalConsumer>
+            { ({ openModal }) => (
+                <Button onClick={ () => openModal(<FadeModal />) }>
+                    Open Modal Imperatively
+                </Button>
+            ) }
+        </ModalGlobalConsumer>
+    )
+};
+
+<ModalGlobalProvider>
+    <OtherComponent />
+    <ParentComponent>
+        <MyComponent />
+    </ParentComponent>
+</ModalGlobalProvider>
+```
+
+## API
+
+### ModalGlobalProvider
+
+This component uses [react context api](https://reactjs.org/docs/context.html) and it will provide two functions to its consumers:
+
+- `closeModal(component)`   
+This function receives the modal component to be closed.
+
+- `openModal(component)`   
+This function receives the modal component to be opened.
+
+**Note:** You must instantiate the provider up higher in your react tree.
+
+### ModalGlobalConsumer
+
+The `<ModalGlobalConsumer>` component allows you to trigger a modal imperatively by providing a children render prop with two props:
+
+- `closeModal(component)`
+
+- `openModal(component)`
+
+### withModalGlobal(component)
+
+The hook version of the <ModalGlobalConsumer> component. The injected props are exactly the same of the <ModalGlobalConsumer> children render prop:
+
+- `closeModal(component)`
+
+- `openModal(component)`

--- a/src/components/modal-global/index.js
+++ b/src/components/modal-global/index.js
@@ -1,0 +1,4 @@
+export { default as ModalGlobalContext } from './ModalGlobalContext';
+export { default as ModalGlobalProvider } from './ModalGlobalProvider';
+export { default as ModalGlobalConsumer } from './ModalGlobalConsumer';
+export { default as withModalGlobal } from './withModalGlobal';

--- a/src/components/modal-global/withModalGlobal.js
+++ b/src/components/modal-global/withModalGlobal.js
@@ -1,0 +1,27 @@
+import React, { PureComponent } from 'react';
+import { PropTypes } from 'prop-types';
+import ModalGlobalConsumer from './ModalGlobalConsumer';
+
+const withModalGlobal = (WrappedComponent) => {
+    class WithModalGlobal extends PureComponent {
+        render() {
+            return (
+                <ModalGlobalConsumer>
+                    { ({ openModal, closeModal }) => (
+                        <WrappedComponent
+                            { ...this.props }
+                            globalModal={ { openModal, closeModal } } />
+                    ) }
+                </ModalGlobalConsumer>
+            );
+        }
+    }
+
+    WithModalGlobal.contextTypes = {
+        globalModal: PropTypes.object,
+    };
+
+    return WithModalGlobal;
+};
+
+export default withModalGlobal;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export { default as IdlePicker } from './components/idle-picker';
 export * from './components/tooltip';
 export * from './components/modal-base';
 export * from './components/modals';
+export * from './components/modal-global';
 export { default as Logo } from './components/logo';
 export { default as Svg } from './components/svg';
 export { default as TypeGroup, TypeOption } from './components/type-group';

--- a/stories/index.js
+++ b/stories/index.js
@@ -17,3 +17,4 @@ import './autocomplete-select';
 import './svg';
 import './radio';
 import './dropdown';
+import './modal-global';

--- a/stories/modal-global.js
+++ b/stories/modal-global.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withReadme } from 'storybook-readme';
+import { Transition } from 'react-transition-group';
+import { ModalGlobalProvider, withModalGlobal, Modal, ModalClose, Button } from '../src';
+import readme from '../src/components/modal-global/README.md';
+
+const WrappedComponent = withModalGlobal(({ globalModal: { openModal } }) => (
+    <Button onClick={ () => openModal(<LoremIpsumModal />) }>
+        Open Modal Imperatively
+    </Button>
+));
+
+const FadeModal = ({ children, ...rest }) => (
+    <Modal { ...rest }>
+        <Transition timeout={ 300 }>
+            { (state) => (
+                <div style={ {
+                    ...{ padding: '5rem', transition: 'opacity 300ms ease-in-out' },
+                    ...{ opacity: state === 'entering' || state === 'entered' ? 1 : 0 },
+                } }>
+                    <ModalClose />
+                    { children }
+                </div>
+            ) }
+        </Transition>
+    </Modal>
+);
+
+const LoremIpsumModal = (props) => (
+    <FadeModal { ...props }>
+        Nullam a felis porta, sollicitudin justo vel, <a href="#foo">dignissim</a> libero.
+        Integer venenatis tincidunt enim, sit amet sagittis erat suscipit et.
+        Aenean consequat erat egestas fringilla bibendum. Ut malesuada risus dui, id maximus dolor accumsan vitae.
+        Pellentesque dictum erat sed auctor suscipit. Aliquam eu iaculis nunc, a gravida nunc.
+        Quisque erat lacus, iaculis ut rutrum id, condimentum id magna. Aliquam at nisi lobortis, gravida mi a, malesuada orci.
+        Pellentesque non sollicitudin est, in rhoncus mauris.
+        Nulla nulla nibh, ultricies ut <a href="#foo">nulla</a> sit amet, scelerisque feugiat neque.
+        Donec at lectus ultrices, sollicitudin lacus ut, cursus eros.
+        Maecenas nunc turpis, vestibulum vitae consequat in, eleifend aliquam mi. Curabitur sed nulla in nisi posuere mattis.
+        Nunc faucibus scelerisque imperdiet. Proin fermentum rutrum quam, vitae sagittis est rhoncus nec.
+        Integer auctor, libero eu convallis pellentesque, odio risus cursus tortor, tincidunt tincidunt magna diam vel magna.
+    </FadeModal>
+);
+
+storiesOf('ModalGlobal', module)
+.addDecorator(withReadme(readme))
+.add('Default', () => (
+    <ModalGlobalProvider>
+        <WrappedComponent />
+    </ModalGlobalProvider>
+));


### PR DESCRIPTION
This PR adds both `<ModalGlobalProvider>` and `<ModalGlobalConsumer>` components. It also adds the `withModalGlobal()` HOC.

This way, we can open and close modals imperatively (i.e. separate from the Component `render` function).