### PR TITLE
fix: feedback-message not changing text color on text-input

### DIFF
--- a/src/components/feedback-message/FeedbackMessage.js
+++ b/src/components/feedback-message/FeedbackMessage.js
@@ -37,7 +37,7 @@ FeedbackTooltip.propTypes = {
     children: PropTypes.node,
 };
 
-const FeedbackMessage = ({ children, type, iconPosition, variant, tooltip, className }) => {
+const FeedbackMessage = ({ children, type, iconPosition, variant, tooltip, className, textColor, ...rest }) => {
     const finalClassNames = classNames(
         styles.feedbackMessage,
         styles[type],
@@ -45,11 +45,12 @@ const FeedbackMessage = ({ children, type, iconPosition, variant, tooltip, class
         styles[variant],
         className
     );
+    const textStyles = type !== 'error' ? { color: textColor } : undefined;
 
     return (
-        <div className={ finalClassNames }>
+        <div className={ finalClassNames } { ...rest }>
             { type && <FeedbackTooltip type={ type }>{ tooltip }</FeedbackTooltip> }
-            { children }
+            <span style={ textStyles }>{ children }</span>
         </div>
     );
 };
@@ -58,6 +59,7 @@ FeedbackMessage.propTypes = {
     children: PropTypes.node.isRequired,
     variant: PropTypes.oneOf(['small', 'large']),
     type: PropTypes.oneOf(['error', 'info']),
+    textColor: PropTypes.string,
     iconPosition: PropTypes.oneOf(['left', 'right']),
     tooltip: PropTypes.node,
     className: PropTypes.string,

--- a/src/components/feedback-message/README.md
+++ b/src/components/feedback-message/README.md
@@ -35,6 +35,7 @@ import { FeedbackMessage } from '@nomios/web-uikit';
 | children | node | *required* | The contents to render, usually a text |
 | variant | string | `small` | The variant of the feedback message, can be one of: `small` or `large` |
 | type | string | | Can be one of: `error` or `info`. Sets the icon accordingly the type. If no type is passed, no icon is applied. |
+| textColor | string |`rgba(75, 69, 61, .6)`| Sets the color of the message. E.g.: `rgb(255, 172, 0)` or `#ffac00`. This prop will be ignored if `type` prop is set to `error`: #d0021b will be applied. |
 | iconPosition | string | `left` | Aligns the icon accordingly the passed value. Can be one of: `left`, `right`. |
 | tooltip | node | | Tooltip content. If this prop is provided, a tooltip is created and it'll be triggered on icon hover. |
 | className | string | | A classname to override styles. |

--- a/src/components/text-input/TextInput.js
+++ b/src/components/text-input/TextInput.js
@@ -83,7 +83,7 @@ class TextInput extends Component {
                 { helperText && <span className={ styles.helperText }>{ helperText }</span> }
                 { feedback && (
                     <FeedbackMessage
-                        style={ { color: this.state.feedbackMessageColor } }
+                        textColor={ this.state.feedbackMessageColor }
                         type={ feedback.type }
                         iconPosition="right"
                         tooltip={ feedback.tooltip }


### PR DESCRIPTION
This PR fixes `<TextInput>` component. It wasn't changing the `<FeedbackMessage>` text color.