### PR TITLE
feat: support custom element in buttons, such as anchors

### DIFF
--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -11,15 +11,19 @@
     height: 5rem;
     overflow: hidden;
     padding: 0;
+    display: inline-block;
     border: none;
     background: transparent;
+    text-decoration: none;
     white-space: nowrap;
+    cursor: pointer;
     transition-property: opacity, box-shadow;
     transition-duration: var(--feedback-transition-duration);
     transition-timing-function: ease-out;
 
-    &:enabled {
-        cursor: pointer;
+    &.disabled {
+        pointer-events: none;
+        cursor: auto;
     }
 
     &.fullWidth {
@@ -34,6 +38,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        text-align: center;
         transition: border-color, color, background-color;
         transition-duration: var(--feedback-transition-duration);
         transition-timing-function: ease-out;
@@ -62,7 +67,7 @@
             color: var(--color-white);
         }
 
-        &:enabled {
+        &:not(.disabled) {
             &:active .textBlock,
             &:focus:not(:hover) .textBlock {
                 background-color: var(--color-dune);
@@ -73,7 +78,7 @@
             }
         }
 
-        &:disabled .textBlock {
+        &.disabled .textBlock {
             background-color: color(var(--color-armadillo) alpha(0.2));
         }
     }
@@ -92,7 +97,7 @@
             }
         }
 
-        &:enabled {
+        &:not(.disabled) {
             &:active,
             &:focus:not(:hover) {
                 box-shadow: inset 0 0 0 0.2rem var(--color-armadillo);
@@ -108,7 +113,7 @@
             }
         }
 
-        &:disabled {
+        &.disabled {
             opacity: 0.3;
         }
     }
@@ -127,7 +132,7 @@
             }
         }
 
-        &:enabled {
+        &:not(.disabled) {
             &:active,
             &:focus:not(:hover) {
                 box-shadow: inset 0 0 0 0.2rem var(--color-white);
@@ -143,7 +148,7 @@
             }
         }
 
-        &:disabled .textBlock {
+        &.disabled .textBlock {
             border-color: color(var(--color-white) alpha(0.3));
             color: color(var(--color-white) alpha(0.5));
         }
@@ -155,7 +160,7 @@
             color: var(--color-armadillo);
         }
 
-        &:enabled {
+        &:not(.disabled) {
             &:active,
             &:focus:not(:hover) {
                 box-shadow: 0 0 0 0.3rem color(var(--color-white) alpha(0.3));
@@ -166,7 +171,7 @@
             }
         }
 
-        &:disabled .textBlock {
+        &.disabled .textBlock {
             background-color: color(var(--color-white) alpha(0.2));
             color: color(var(--color-armadillo) alpha(0.5));
         }

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -23,7 +23,7 @@ class Button extends Component {
     }
 
     render() {
-        const { variant, feedback: _, fullWidth, disabled, className, children, ...rest } = this.props;
+        const { element, variant, feedback: _, fullWidth, disabled, className, children, ...rest } = this.props;
         const { feedback, progressbarAnimationEnded, feedbackIconAnimationEnded } = this.state;
         const hasFeedback = feedback !== 'none';
 
@@ -31,14 +31,20 @@ class Button extends Component {
         const finalClassName = classNames(
             styles.button,
             styles[variant],
+            finalDisabled && styles.disabled,
             hasFeedback && !progressbarAnimationEnded ? styles.loading : styles[feedback],
             hasFeedback && !feedbackIconAnimationEnded && styles.progressVisible,
             fullWidth && styles.fullWidth,
-            className
+            element.props.className,
+            className,
         );
 
         return (
-            <button { ...rest } disabled={ finalDisabled } className={ finalClassName }>
+            <element.type
+                { ...element.props }
+                { ...rest }
+                { ...this.getDisabledProps(finalDisabled) }
+                className={ finalClassName }>
                 <div className={ styles.textBlock }>
                     <span className={ styles.text }>{ children }</span>
 
@@ -54,8 +60,20 @@ class Button extends Component {
                 <span className={ styles.errorBlock }>
                     <CrossmarkIcon className={ styles.crossmark } onTransitionEnd={ this.handleErrorIconTransitionEnd } />
                 </span>
-            </button>
+            </element.type>
         );
+    }
+
+    getDisabledProps(disabled) {
+        if (!disabled) {
+            return {};
+        }
+
+        const elementType = this.props.element.type;
+
+        return elementType === 'button' ?
+            { disabled: true } :
+            { 'aria-disabled': 'true', tabIndex: '-1' };
     }
 
     handleFeedbackChange(prevFeedback) {
@@ -98,11 +116,13 @@ Button.propTypes = {
     disabled: PropTypes.bool,
     fullWidth: PropTypes.bool,
     feedback: PropTypes.oneOf(['none', 'loading', 'success', 'error']),
+    element: PropTypes.element,
     children: PropTypes.node,
     className: PropTypes.string,
 };
 
 Button.defaultProps = {
+    element: <button />,
     variant: 'primary',
     feedback: 'none',
 };

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -10,6 +10,18 @@ import { Button } from '@nomios/web-uikit';
 <Button variant="primary" onClick={ handleClick } />
 ```
 
+### As an anchor
+
+```jsx
+import { Button } from '@nomios/web-uikit';
+
+<Button
+    element={ <a href="http://google.com" rel="noopener noreferrer" target="_blank" /> }
+    variant="primary" />
+```
+
+If a custom `element` prop is passed, the `aria-disabled` and `z-index` attributes will be set accordingly.
+
 ## Props
 
 | name | type | default | description |
@@ -18,5 +30,6 @@ import { Button } from '@nomios/web-uikit';
 | disabled | boolean | false | Sets the disable state |
 | fullWidth | boolean | false | Sets button width to 100% |
 | feedback | string | | Sets the current feedback of the button. Can be one of: `none`, `loading`, `success`, `error` |
+| element | element | `<button />` | The element to use, useful to render a anchor instead of a button |
 
 **Note:** Any other properties supplied to this component will be spread to the root element.

--- a/stories/button.js
+++ b/stories/button.js
@@ -32,6 +32,7 @@ storiesOf('Button', module)
     const disabled = boolean('disabled', false);
     const fullWidth = boolean('fullWidth', false);
     const feedback = select('feedback', ['none', 'loading', 'success', 'error'], 'none');
+    const anchor = boolean('anchor', false);
     const children = text('children', 'Click me');
 
     return (
@@ -40,6 +41,7 @@ storiesOf('Button', module)
             disabled={ disabled }
             fullWidth={ fullWidth }
             feedback={ feedback }
+            element={ anchor ? <a href="http://google.com" rel="noopener noreferrer" target="_blank" /> : undefined }
             onClick={ action('clicked') }>
             { children }
         </Button>


### PR DESCRIPTION
When this gets merged, we should search for all `<a>` wrapping buttons in `nomios-web`, and update to use the new `element` prop.